### PR TITLE
✨ [Feature] 사용자 정보 조회 API, 사용자 설정 업데이트 API

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { DatabaseConfigService } from './config/database/configuration.service';
 import { Member } from './entities/member.entity';
 import { Restaurant } from './entities/restaurant.entity';
 import { Review } from './entities/review.entity';
+import { MembersModule } from './members/members.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { Review } from './entities/review.entity';
     }),
     //FIXME: 테이블 생성을 위한 것으로 추후 삭제합니다.
     TypeOrmModule.forFeature([Member, Restaurant, Review]),
+    MembersModule,
   ],
 })
 export class AppModule {}

--- a/src/members/dto/member-response.dto.ts
+++ b/src/members/dto/member-response.dto.ts
@@ -1,0 +1,8 @@
+import { OmitType } from '@nestjs/swagger';
+
+import { Member } from '../../entities/member.entity';
+
+export class MemberResponseDto extends OmitType(Member, ['password', 'reviews', 'location']) {
+  lon: number;
+  lat: number;
+}

--- a/src/members/dto/update-member-settings.dto.ts
+++ b/src/members/dto/update-member-settings.dto.ts
@@ -1,6 +1,6 @@
 import { IsBoolean, IsLatitude, IsLongitude, IsNotEmpty } from 'class-validator';
 
-export class UpdateMemberDto {
+export class UpdateMemberSettingsDto {
   /**
    * 사용자의 위도
    * @example 37.564625

--- a/src/members/dto/update-member.dto.ts
+++ b/src/members/dto/update-member.dto.ts
@@ -1,14 +1,26 @@
 import { IsBoolean, IsLatitude, IsLongitude, IsNotEmpty } from 'class-validator';
 
 export class UpdateMemberDto {
+  /**
+   * 사용자의 위도
+   * @example 37.564625
+   */
   @IsLatitude()
   @IsNotEmpty()
   lat: number;
 
+  /**
+   * 사용자의 경도
+   * @example 126.977260
+   */
   @IsLongitude()
   @IsNotEmpty()
   lon: number;
 
+  /**
+   * 추천 기능 사용 여부
+   * @example true
+   */
   @IsBoolean()
   @IsNotEmpty()
   isRecommendationEnabled: boolean;

--- a/src/members/dto/update-member.dto.ts
+++ b/src/members/dto/update-member.dto.ts
@@ -1,0 +1,15 @@
+import { IsBoolean, IsLatitude, IsLongitude, IsNotEmpty } from 'class-validator';
+
+export class UpdateMemberDto {
+  @IsLatitude()
+  @IsNotEmpty()
+  lat: number;
+
+  @IsLongitude()
+  @IsNotEmpty()
+  lon: number;
+
+  @IsBoolean()
+  @IsNotEmpty()
+  isRecommendationEnabled: boolean;
+}

--- a/src/members/members.controller.ts
+++ b/src/members/members.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Param } from '@nestjs/common';
+
+import { MemberResponseDto } from './dto/member-response.dto';
+import { MembersService } from './members.service';
+
+@Controller('members')
+export class MembersController {
+  constructor(private readonly membersService: MembersService) {}
+
+  @Get(':id')
+  async findOne(@Param('id') id: string): Promise<MemberResponseDto> {
+    return await this.membersService.findOne(id);
+  }
+}

--- a/src/members/members.controller.ts
+++ b/src/members/members.controller.ts
@@ -1,18 +1,30 @@
 import { Controller, Get, Body, Patch, Param, HttpStatus, HttpCode } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 
 import { MemberResponseDto } from './dto/member-response.dto';
 import { UpdateMemberDto } from './dto/update-member.dto';
 import { MembersService } from './members.service';
 
 @Controller('members')
+@ApiTags('members')
 export class MembersController {
   constructor(private readonly membersService: MembersService) {}
 
+  /**
+   * 사용자 정보 조회 API
+   * @param id 사용자 PK
+   * @returns 패스워드를 제외한 모든 사용자 정보
+   */
   @Get(':id')
   async findOne(@Param('id') id: string): Promise<MemberResponseDto> {
     return await this.membersService.findOne(id);
   }
 
+  /**
+   * 사용자 설정 업데이트 API
+   * @param id 사용자 PK
+   * @param updateMemberDto 업데이트 할 정보
+   */
   @Patch(':id/settings')
   @HttpCode(HttpStatus.NO_CONTENT)
   updateSettings(@Param('id') id: string, @Body() updateMemberDto: UpdateMemberDto): void {

--- a/src/members/members.controller.ts
+++ b/src/members/members.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Body, Patch, Param, HttpStatus, HttpCode } from '@nest
 import { ApiTags } from '@nestjs/swagger';
 
 import { MemberResponseDto } from './dto/member-response.dto';
-import { UpdateMemberDto } from './dto/update-member.dto';
+import { UpdateMemberSettingsDto } from './dto/update-member-settings.dto';
 import { MembersService } from './members.service';
 
 @Controller('members')
@@ -23,11 +23,11 @@ export class MembersController {
   /**
    * 사용자 설정 업데이트 API
    * @param id 사용자 PK
-   * @param updateMemberDto 업데이트 할 정보
+   * @param UpdateMemberSettingsDto 업데이트 할 정보
    */
   @Patch(':id/settings')
   @HttpCode(HttpStatus.NO_CONTENT)
-  updateSettings(@Param('id') id: string, @Body() updateMemberDto: UpdateMemberDto): void {
-    this.membersService.updateSettings(id, updateMemberDto);
+  updateSettings(@Param('id') id: string, @Body() updateMemberSettingsDto: UpdateMemberSettingsDto): void {
+    this.membersService.updateSettings(id, updateMemberSettingsDto);
   }
 }

--- a/src/members/members.controller.ts
+++ b/src/members/members.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Body, Patch, Param, HttpStatus, HttpCode } from '@nestjs/common';
 
 import { MemberResponseDto } from './dto/member-response.dto';
+import { UpdateMemberDto } from './dto/update-member.dto';
 import { MembersService } from './members.service';
 
 @Controller('members')
@@ -10,5 +11,11 @@ export class MembersController {
   @Get(':id')
   async findOne(@Param('id') id: string): Promise<MemberResponseDto> {
     return await this.membersService.findOne(id);
+  }
+
+  @Patch(':id/settings')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  updateSettings(@Param('id') id: string, @Body() updateMemberDto: UpdateMemberDto): void {
+    this.membersService.updateSettings(id, updateMemberDto);
   }
 }

--- a/src/members/members.controller.ts
+++ b/src/members/members.controller.ts
@@ -5,8 +5,8 @@ import { MemberResponseDto } from './dto/member-response.dto';
 import { UpdateMemberSettingsDto } from './dto/update-member-settings.dto';
 import { MembersService } from './members.service';
 
-@Controller('members')
 @ApiTags('members')
+@Controller('members')
 export class MembersController {
   constructor(private readonly membersService: MembersService) {}
 

--- a/src/members/members.service.ts
+++ b/src/members/members.service.ts
@@ -5,6 +5,7 @@ import { Repository } from 'typeorm';
 import { Member } from '../entities/member.entity';
 
 import { MemberResponseDto } from './dto/member-response.dto';
+import { UpdateMemberDto } from './dto/update-member.dto';
 
 @Injectable()
 export class MembersService {
@@ -29,6 +30,23 @@ export class MembersService {
       createdAt: member.createdAt,
       updatedAt: member.updatedAt,
     };
+  }
+
+  /**
+   * 사용자의 위도, 경도, 추천 기능 사용 여부를 업데이트 합니다.
+   * @param id 사용자 PK
+   * @param updateMemberDto 업데이트 할 정보
+   */
+  async updateSettings(id: string, updateMemberDto: UpdateMemberDto): Promise<void> {
+    const { lon, lat, isRecommendationEnabled } = updateMemberDto;
+
+    // 사용자 not found 예외처리
+    await this.findMemberById(id);
+
+    this.memberRepository.update(
+      { id },
+      { location: () => `ST_SetSRID(ST_MakePoint(${lon}, ${lat}),4326)`, isRecommendationEnabled },
+    );
   }
 
   // 전달 받은 id 인자로 사용자를 찾아 반환합니다. 존재하지 않는 사용자라면 에러를 발생시킵니다.

--- a/src/members/members.service.ts
+++ b/src/members/members.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { Member } from '../entities/member.entity';
+
+import { MemberResponseDto } from './dto/member-response.dto';
+
+@Injectable()
+export class MembersService {
+  constructor(@InjectRepository(Member) private readonly memberRepository: Repository<Member>) {}
+
+  /**
+   * id 경로 변수로 사용자를 찾아 반환합니다.
+   * @param id 사용자 PK
+   * @returns 패스워드를 제외한 모든 사용자 정보
+   */
+  async findOne(id: string): Promise<MemberResponseDto> {
+    const member = await this.findMemberById(id);
+    const [lat, lon] = member.location?.coordinates;
+
+    return {
+      id: member.id,
+      accountName: member.accountName,
+      name: member.name,
+      lat,
+      lon,
+      isRecommendationEnabled: member.isRecommendationEnabled,
+      createdAt: member.createdAt,
+      updatedAt: member.updatedAt,
+    };
+  }
+
+  // 전달 받은 id 인자로 사용자를 찾아 반환합니다. 존재하지 않는 사용자라면 에러를 발생시킵니다.
+  private async findMemberById(id: string): Promise<Member> {
+    const member = await this.memberRepository.findOneBy({ id });
+
+    if (member === null) {
+      throw new NotFoundException('member not found');
+    }
+
+    return member;
+  }
+}

--- a/src/members/members.service.ts
+++ b/src/members/members.service.ts
@@ -5,7 +5,7 @@ import { Repository } from 'typeorm';
 import { Member } from '../entities/member.entity';
 
 import { MemberResponseDto } from './dto/member-response.dto';
-import { UpdateMemberDto } from './dto/update-member.dto';
+import { UpdateMemberSettingsDto } from './dto/update-member-settings.dto';
 
 @Injectable()
 export class MembersService {
@@ -37,8 +37,8 @@ export class MembersService {
    * @param id 사용자 PK
    * @param updateMemberDto 업데이트 할 정보
    */
-  async updateSettings(id: string, updateMemberDto: UpdateMemberDto): Promise<void> {
-    const { lon, lat, isRecommendationEnabled } = updateMemberDto;
+  async updateSettings(id: string, updateMemberSettingsDto: UpdateMemberSettingsDto): Promise<void> {
+    const { lon, lat, isRecommendationEnabled } = updateMemberSettingsDto;
 
     // 사용자 not found 예외처리
     await this.findMemberById(id);


### PR DESCRIPTION
## Summary
`GET api/members/:id` 사용자 정보 조회 API  
`PATCH api/members/:id/settings` 사용자 설정 업데이트 API  
구현하였습니다.

## Describe your changes
- `members.module`, `members.controller`, `members.service` 파일 생성해 비즈니스 로직 작성하였습니다.
- API 구현에 필요한 `update-member-settings.dto`, `member-response.dto` 파일 생성했습니다.
- PostGIS에서 위도, 경도 값을 Point 객체로 변환할 때 많이 쓰이는 `ST_GeomFromText`보다 `ST_MakePoint`가 더 빠르고 정확하다기에 사용하였고, `ST_SetSRID`로 좌표계를 WGS84(EPSG:4326)로 설정하였습니다. [(참고)](https://postgis.net/docs/ST_MakePoint.html)
- 스웨거 적용
  - param, returns와 같은 기본적인 설명 작성했습니다.
  - 컨트롤러 스코프로 `@ApiTags` 데코레이터를 사용해 문서에서 구분 되도록 했습니다.
  - request dto에 설명과 example 작성했습니다.

## Issue number and link
#10 
#12 

- auth 머지 된 이후 가드 붙일 예정입니다.
- 테스트 코드 작성도 그때 같이 해서 다시 PR 올리겠습니다!