### PR TITLE
✨ [Feature] 테스트를 위한 DB 데이터 시딩

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "typeorm-naming-strategies": "^4.1.0"
       },
       "devDependencies": {
+        "@faker-js/faker": "^8.4.1",
         "@nestjs/cli": "^10.0.0",
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",
@@ -968,6 +969,23 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@hapi/hoek": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "docker:dev": "docker compose -f docker-compose.dev.yml up -d --build",
     "docker:dev:down": "docker compose -f docker-compose.dev.yml down",
     "docker:prod": "docker compose -f docker-compose.yml up -d --build",
-    "docker:prod:down": "docker compose -f docker-compose.yml down"
+    "docker:prod:down": "docker compose -f docker-compose.yml down",
+    "seed": "npx ts-node src/database/data-source.ts"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
@@ -40,6 +41,7 @@
     "typeorm-naming-strategies": "^4.1.0"
   },
   "devDependencies": {
+    "@faker-js/faker": "^8.4.1",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -1,0 +1,57 @@
+import { config } from 'dotenv';
+import { DataSource, DataSourceOptions } from 'typeorm';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+
+import seeder from './seeds/seeder';
+
+config();
+
+// seeding 10 companies
+(async () => {
+  console.log('Seeding data...');
+  if (process.argv[2] === undefined) {
+    console.log('Please enter the number of users to be created.');
+    console.log('ex) npm run seed 300\n');
+    process.exit(1);
+  }
+
+  const options: DataSourceOptions = {
+    type: 'postgres',
+    host: process.env.POSTGRES_HOST || 'localhost',
+    port: parseInt(process.env.POSTGRES_PORT || '5432'),
+    username: process.env.POSTGRES_USER,
+    password: process.env.POSTGRES_PASSWORD,
+    database: process.env.POSTGRES_DB,
+    synchronize: true,
+    entities: ['./src/entities/*.ts'],
+    namingStrategy: new SnakeNamingStrategy(),
+    logging: true,
+  };
+
+  const dataSource: DataSource = new DataSource(options);
+
+  try {
+    await dataSource.initialize();
+  } catch (e) {
+    console.table(e);
+    console.error(e);
+    if (e.code === 'ENOTFOUND') {
+      console.error('Please check the database connection options in the .env file.\n');
+    }
+    await dataSource.destroy();
+    process.exit(1);
+  }
+  try {
+    const result = await seeder(dataSource);
+    result.map((r, i) => console.log(`Created ${r} ${['members', 'restaurants', 'reviews'][i]}`));
+  } catch (e) {
+    console.error(e);
+    if (e.code === '23505') {
+      // already exists
+      console.error('\nSeeding data already exists.\n');
+    }
+    await dataSource.destroy();
+    process.exit(1);
+  }
+  await dataSource.destroy();
+})();

--- a/src/database/factory/base-model.factory.ts
+++ b/src/database/factory/base-model.factory.ts
@@ -1,0 +1,13 @@
+import { faker } from '@faker-js/faker';
+
+import { BaseModel } from '../../entities/base-model.entity';
+
+export const BaseModelFactory = (): BaseModel => {
+  // 23년 1월 ~ 현재 날짜 사이의 날짜를 랜덤으로 생성
+  const [createdAt, updatedAt] = faker.date.betweens({ from: '2023-01-01', to: new Date(), count: 2 });
+  return {
+    id: faker.string.uuid(),
+    createdAt,
+    updatedAt,
+  };
+};

--- a/src/database/factory/member.factory.ts
+++ b/src/database/factory/member.factory.ts
@@ -1,0 +1,15 @@
+import { faker } from '@faker-js/faker';
+
+import { BaseModelFactory } from './base-model.factory';
+
+export const memberFactory = () => {
+  const location = { type: 'Point', coordinates: [faker.location.longitude(), faker.location.latitude()] };
+  return {
+    ...BaseModelFactory(),
+    name: faker.person.fullName(),
+    accountName: faker.internet.userName(),
+    password: faker.internet.password(),
+    isRecommendationEnabled: faker.datatype.boolean(),
+    location,
+  };
+};

--- a/src/database/factory/member.factory.ts
+++ b/src/database/factory/member.factory.ts
@@ -3,7 +3,10 @@ import { faker } from '@faker-js/faker';
 import { BaseModelFactory } from './base-model.factory';
 
 export const memberFactory = () => {
-  const location = { type: 'Point', coordinates: [faker.location.longitude(), faker.location.latitude()] };
+  const location = {
+    type: 'Point',
+    coordinates: [faker.location.longitude({ min: 126, max: 128 }), faker.location.latitude({ min: 36, max: 38 })],
+  };
   return {
     ...BaseModelFactory(),
     name: faker.person.fullName(),

--- a/src/database/factory/restaurant.factory.ts
+++ b/src/database/factory/restaurant.factory.ts
@@ -1,0 +1,16 @@
+import { faker } from '@faker-js/faker';
+
+import { BaseModelFactory } from './base-model.factory';
+
+export const restaurantFactory = () => {
+  const location = { type: 'Point', coordinates: [faker.location.longitude(), faker.location.latitude()] };
+  return {
+    ...BaseModelFactory(),
+    name: faker.string.alphanumeric({ length: { min: 10, max: 40 } }),
+    category: faker.string.alphanumeric({ length: { min: 3, max: 10 } }),
+    phoneNumber: faker.phone.number(),
+    address: faker.location.streetAddress({ useFullAddress: true }),
+    location,
+    rating: faker.number.float({ min: 1, max: 5 }),
+  };
+};

--- a/src/database/factory/restaurant.factory.ts
+++ b/src/database/factory/restaurant.factory.ts
@@ -3,7 +3,10 @@ import { faker } from '@faker-js/faker';
 import { BaseModelFactory } from './base-model.factory';
 
 export const restaurantFactory = () => {
-  const location = { type: 'Point', coordinates: [faker.location.longitude(), faker.location.latitude()] };
+  const location = {
+    type: 'Point',
+    coordinates: [faker.location.longitude({ min: 126, max: 128 }), faker.location.latitude({ min: 36, max: 38 })],
+  };
   return {
     ...BaseModelFactory(),
     name: faker.string.alphanumeric({ length: { min: 10, max: 40 } }),

--- a/src/database/factory/review.factory.ts
+++ b/src/database/factory/review.factory.ts
@@ -1,0 +1,13 @@
+import { faker } from '@faker-js/faker';
+
+import { BaseModelFactory } from './base-model.factory';
+
+type ReviewFactoryParams = { memberId?: string; restaurantId?: string };
+
+export const reviewFactory = ({ memberId, restaurantId }: ReviewFactoryParams) => ({
+  ...BaseModelFactory(),
+  content: faker.lorem.paragraph(),
+  rating: faker.number.int({ min: 1, max: 5 }),
+  memberId,
+  restaurantId,
+});

--- a/src/database/seeds/seeder.ts
+++ b/src/database/seeds/seeder.ts
@@ -1,0 +1,29 @@
+import { DataSource } from 'typeorm';
+
+import { memberFactory } from '../factory/member.factory';
+import { restaurantFactory } from '../factory/restaurant.factory';
+import { reviewFactory } from '../factory/review.factory';
+
+export default async (dataSource: DataSource): Promise<number[]> => {
+  return dataSource.transaction(async (manager) => {
+    const memberSeeds = Array(+process.argv[2]).fill(0).map(memberFactory);
+    const memberResult = await manager.getRepository('Member').save(memberSeeds);
+
+    const restaurantSeeds = Array(+process.argv[2]).fill(0).map(restaurantFactory);
+    const restaurantResult = await manager.getRepository('Restaurant').save(restaurantSeeds);
+
+    // review 데이터 생성
+    // ? memberId, restaurantId는 이중 반복문으로
+    const reviewSeeds = [
+      ...memberResult.map((member) => {
+        return restaurantResult.map((restaurant) =>
+          reviewFactory({ memberId: member.id, restaurantId: restaurant.id }),
+        );
+      }),
+    ];
+
+    const reviewResult = await manager.getRepository('Review').save(reviewSeeds.flat());
+
+    return [memberResult.length, restaurantResult.length, reviewResult.length];
+  });
+};


### PR DESCRIPTION
## Summary

- `faker.js` 라이브러리를 통해 db에 데이터를 시딩하는 기능 구현
- `npm run seed {count}` 를 통해 원하는 만큼의 데이터를 생성

## Describe your changes

- 외래키 지정을 위해 `member`, `restaurant` -> `review` 순으로 데이터를 생성함
- review는 member * restaurant 개수 만큼 생성됨
- 사용자, 맛집의 위치는 테스트를 위해 서울 주변으로 제한함

## Issue number and link
closed #20 
