### PR TITLE
✨ [Feature] 맛집 목록 조회 API, 맛집 상세 조회 API

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { Member } from './entities/member.entity';
 import { Restaurant } from './entities/restaurant.entity';
 import { Review } from './entities/review.entity';
 import { MembersModule } from './members/members.module';
+import { RestaurantsModule } from './restaurants/restaurants.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { MembersModule } from './members/members.module';
     //FIXME: 테이블 생성을 위한 것으로 추후 삭제합니다.
     TypeOrmModule.forFeature([Member, Restaurant, Review]),
     MembersModule,
+    RestaurantsModule,
   ],
 })
 export class AppModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
@@ -13,6 +14,12 @@ const config = new DocumentBuilder()
 const bootstrap = async (): Promise<void> => {
   const app = await NestFactory.create(AppModule);
   app.setGlobalPrefix('/api');
+  app.useGlobalPipes(
+    new ValidationPipe({
+      stopAtFirstError: true, // 맨 처음 발생한 하나의 에러만 반환 (나머지 검증 skip)
+      whitelist: true, // 없는 속성 제거
+    }),
+  );
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);

--- a/src/restaurants/dto/restaurant-query.dto.ts
+++ b/src/restaurants/dto/restaurant-query.dto.ts
@@ -1,5 +1,5 @@
 import { Type } from 'class-transformer';
-import { IsEnum, IsNumber, IsOptional } from 'class-validator';
+import { IsEnum, IsLatitude, IsLongitude, IsNumber, IsOptional } from 'class-validator';
 
 enum OrderBy {
   DISTANCE = 'distance',
@@ -12,14 +12,26 @@ enum SortBy {
 }
 
 export class RestaurantQueryDto {
-  @IsNumber()
+  /**
+   * 경도
+   * @example 126.9530
+   */
+  @IsLongitude()
   @Type(() => Number)
   readonly lon: number;
 
-  @IsNumber()
+  /**
+   * 위도
+   * @example 37.5616
+   */
+  @IsLatitude()
   @Type(() => Number)
   readonly lat: number;
 
+  /**
+   * 범위
+   * @example 200000
+   */
   @IsNumber()
   @Type(() => Number)
   readonly range: number;

--- a/src/restaurants/dto/restaurant-query.dto.ts
+++ b/src/restaurants/dto/restaurant-query.dto.ts
@@ -1,12 +1,12 @@
 import { Type } from 'class-transformer';
 import { IsEnum, IsLatitude, IsLongitude, IsNumber, IsOptional } from 'class-validator';
 
-enum OrderBy {
+export enum OrderBy {
   DISTANCE = 'distance',
   RATING = 'rating',
 }
 
-enum SortBy {
+export enum SortBy {
   DESC = 'DESC',
   ASC = 'ASC',
 }

--- a/src/restaurants/dto/restaurant-query.dto.ts
+++ b/src/restaurants/dto/restaurant-query.dto.ts
@@ -1,0 +1,42 @@
+import { Type } from 'class-transformer';
+import { IsEnum, IsNumber, IsOptional } from 'class-validator';
+
+enum OrderBy {
+  DISTANCE = 'distance',
+  RATING = 'rating',
+}
+
+enum SortBy {
+  DESC = 'DESC',
+  ASC = 'ASC',
+}
+
+export class RestaurantQueryDto {
+  @IsNumber()
+  @Type(() => Number)
+  readonly lon: number;
+
+  @IsNumber()
+  @Type(() => Number)
+  readonly lat: number;
+
+  @IsNumber()
+  @Type(() => Number)
+  readonly range: number;
+
+  @IsEnum(OrderBy)
+  @IsOptional()
+  readonly orderBy?: OrderBy = OrderBy.RATING;
+
+  @IsEnum(SortBy)
+  @IsOptional()
+  readonly sortBy?: 'DESC' | 'ASC' = SortBy.DESC;
+
+  @IsNumber()
+  @IsOptional()
+  readonly pageSize?: number = 10;
+
+  @IsNumber()
+  @IsOptional()
+  readonly page?: number = 0;
+}

--- a/src/restaurants/dto/restaurant-response.dto.ts
+++ b/src/restaurants/dto/restaurant-response.dto.ts
@@ -1,0 +1,12 @@
+import { OmitType } from '@nestjs/swagger';
+
+import { Restaurant } from '../../entities/restaurant.entity';
+import { Review } from '../../entities/review.entity';
+
+class ReviewResponseDto extends OmitType(Review, ['member', 'createdAt', 'updatedAt', 'restaurant']) {}
+
+export class RestaurantResponseDto extends OmitType(Restaurant, ['reviews', 'createdAt', 'updatedAt', 'location']) {
+  readonly lon: number;
+  readonly lat: number;
+  readonly reviews?: ReviewResponseDto[];
+}

--- a/src/restaurants/dto/restaurant-response.dto.ts
+++ b/src/restaurants/dto/restaurant-response.dto.ts
@@ -9,4 +9,5 @@ export class RestaurantResponseDto extends OmitType(Restaurant, ['reviews', 'cre
   readonly lon: number;
   readonly lat: number;
   readonly reviews?: ReviewResponseDto[];
+  readonly distance?: number;
 }

--- a/src/restaurants/restaurants.controller.spec.ts
+++ b/src/restaurants/restaurants.controller.spec.ts
@@ -1,15 +1,28 @@
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { OrderBy, RestaurantQueryDto, SortBy } from './dto/restaurant-query.dto';
+import { RestaurantResponseDto } from './dto/restaurant-response.dto';
 import { RestaurantsController } from './restaurants.controller';
 import { RestaurantsService } from './restaurants.service';
 
 describe('RestaurantsController', () => {
   let controller: RestaurantsController;
 
+  const mockRestaurantsService = {
+    findList: jest.fn(),
+    findOneDetail: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RestaurantsController],
-      providers: [RestaurantsService],
+      providers: [
+        {
+          provide: RestaurantsService,
+          useValue: mockRestaurantsService,
+        },
+      ],
     }).compile();
 
     controller = module.get<RestaurantsController>(RestaurantsController);
@@ -17,5 +30,81 @@ describe('RestaurantsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('findList', () => {
+    it('should return an array of restaurants', async () => {
+      const queryDto: RestaurantQueryDto = {
+        lon: 127.0,
+        lat: 37.5,
+        range: 1000,
+        sortBy: SortBy.ASC,
+        orderBy: OrderBy.DISTANCE,
+        page: 0,
+        pageSize: 10,
+      };
+
+      const mockResponse: RestaurantResponseDto[] = [
+        {
+          id: '1',
+          name: 'Restaurant A',
+          address: '123 Main St',
+          phoneNumber: '123-456-7890',
+          category: 'Italian',
+          rating: 4.5,
+          lat: 37.5,
+          lon: 127.0,
+          distance: 500,
+        },
+      ];
+
+      mockRestaurantsService.findList.mockResolvedValue(mockResponse);
+
+      const result = await controller.findList(queryDto);
+      expect(result).toEqual(mockResponse);
+      expect(mockRestaurantsService.findList).toHaveBeenCalledWith({
+        lon: queryDto.lon,
+        lat: queryDto.lat,
+        range: queryDto.range,
+        sortBy: queryDto.sortBy,
+        orderBy: queryDto.orderBy,
+        page: queryDto.page,
+        pageSize: queryDto.pageSize,
+      });
+    });
+  });
+
+  describe('findOneDetail', () => {
+    it('should return a restaurant detail', async () => {
+      const id = '1';
+      const mockResponse: RestaurantResponseDto = {
+        id: '1',
+        name: 'Restaurant A',
+        address: '123 Main St',
+        phoneNumber: '123-456-7890',
+        category: 'Italian',
+        rating: 4.5,
+        lat: 37.5,
+        lon: 127.0,
+        distance: 500,
+        reviews: [{ id: '1', content: 'Great food!', rating: 5, memberId: 'test', restaurantId: 'test' }],
+      };
+
+      mockRestaurantsService.findOneDetail.mockResolvedValue(mockResponse);
+
+      const result = await controller.findOneDetail(id);
+      expect(result).toEqual(mockResponse);
+      expect(mockRestaurantsService.findOneDetail).toHaveBeenCalledWith(id);
+    });
+
+    it('should throw NotFoundException if restaurant is not found', async () => {
+      const id = '1';
+      mockRestaurantsService.findOneDetail.mockImplementation(() => {
+        throw new NotFoundException('Restaurant not found');
+      });
+
+      await expect(controller.findOneDetail(id)).rejects.toThrow(NotFoundException);
+      expect(mockRestaurantsService.findOneDetail).toHaveBeenCalledWith(id);
+    });
   });
 });

--- a/src/restaurants/restaurants.controller.spec.ts
+++ b/src/restaurants/restaurants.controller.spec.ts
@@ -33,7 +33,7 @@ describe('RestaurantsController', () => {
   });
 
   describe('findList', () => {
-    it('should return an array of restaurants', async () => {
+    it('Restaurant 배열이 반환됩니다.', async () => {
       const queryDto: RestaurantQueryDto = {
         lon: 127.0,
         lat: 37.5,
@@ -75,7 +75,7 @@ describe('RestaurantsController', () => {
   });
 
   describe('findOneDetail', () => {
-    it('should return a restaurant detail', async () => {
+    it('Restaurant의 상세 정보가 반환됩니다.', async () => {
       const id = '1';
       const mockResponse: RestaurantResponseDto = {
         id: '1',
@@ -97,7 +97,7 @@ describe('RestaurantsController', () => {
       expect(mockRestaurantsService.findOneDetail).toHaveBeenCalledWith(id);
     });
 
-    it('should throw NotFoundException if restaurant is not found', async () => {
+    it('Restaurant가 없으면 Not Found로 처리됩니다.', async () => {
       const id = '1';
       mockRestaurantsService.findOneDetail.mockImplementation(() => {
         throw new NotFoundException('Restaurant not found');

--- a/src/restaurants/restaurants.controller.spec.ts
+++ b/src/restaurants/restaurants.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+
 import { RestaurantsController } from './restaurants.controller';
 import { RestaurantsService } from './restaurants.service';
 

--- a/src/restaurants/restaurants.controller.ts
+++ b/src/restaurants/restaurants.controller.ts
@@ -39,6 +39,11 @@ export class RestaurantsController {
     return res.status(HttpStatus.CREATED).setHeader('Location', location).json({ id: review.id });
   }
 
+  /*
+   * 특정 위치를 기준으로 일정 거리 안에 있는 맛집들을 조회합니다.
+   * @param queries 검색 조건
+   * @returns 맛집 목록
+   */
   @Get()
   async findList(@Query() queries: RestaurantQueryDto): Promise<Restaurant[]> {
     const restaurants = await this.restaurantsService.findList({
@@ -54,6 +59,11 @@ export class RestaurantsController {
     return restaurants;
   }
 
+  /**
+   * 맛집id를 통해 맛집의 상세 정보를 조회합니다.
+   * @param id 맛집 id
+   * @returns 리뷰를 포함한 맛집 상세 정보
+   */
   @Get(':id')
   async findOneDetail(@Param('id') id: string): Promise<Restaurant | null> {
     const restaurant = await this.restaurantsService.findOneDetail(id);

--- a/src/restaurants/restaurants.controller.ts
+++ b/src/restaurants/restaurants.controller.ts
@@ -7,6 +7,7 @@ import { Restaurant } from '../entities/restaurant.entity';
 
 import { CreateReviewDto } from './dto/create-review.dto';
 import { RestaurantQueryDto } from './dto/restaurant-query.dto';
+import { RestaurantResponseDto } from './dto/restaurant-response.dto';
 import { RestaurantsService } from './restaurants.service';
 
 export type MemberRequest = Request & {
@@ -45,7 +46,7 @@ export class RestaurantsController {
    * @returns 맛집 목록
    */
   @Get()
-  async findList(@Query() queries: RestaurantQueryDto): Promise<Restaurant[]> {
+  async findList(@Query() queries: RestaurantQueryDto): Promise<RestaurantResponseDto[]> {
     const restaurants = await this.restaurantsService.findList({
       lon: queries.lon,
       lat: queries.lat,
@@ -65,7 +66,7 @@ export class RestaurantsController {
    * @returns 리뷰를 포함한 맛집 상세 정보
    */
   @Get(':id')
-  async findOneDetail(@Param('id') id: string): Promise<Restaurant | null> {
+  async findOneDetail(@Param('id') id: string): Promise<RestaurantResponseDto | null> {
     const restaurant = await this.restaurantsService.findOneDetail(id);
 
     return restaurant;

--- a/src/restaurants/restaurants.controller.ts
+++ b/src/restaurants/restaurants.controller.ts
@@ -1,18 +1,20 @@
-import { Controller, Post, Body, Param, Res, HttpStatus, Req } from '@nestjs/common';
+import { Controller, Post, Body, Param, Res, HttpStatus, Req, Get, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 
 import { Member } from '../entities/member.entity';
+import { Restaurant } from '../entities/restaurant.entity';
 
 import { CreateReviewDto } from './dto/create-review.dto';
+import { RestaurantQueryDto } from './dto/restaurant-query.dto';
 import { RestaurantsService } from './restaurants.service';
 
 export type MemberRequest = Request & {
   member: Member;
 };
 
-@ApiTags('restaurants')
 @Controller('restaurants')
+@ApiTags('restaurants')
 export class RestaurantsController {
   constructor(private readonly restaurantsService: RestaurantsService) {}
 
@@ -35,5 +37,20 @@ export class RestaurantsController {
     const location = `${req.path}/${review.id}`;
 
     return res.status(HttpStatus.CREATED).setHeader('Location', location).json({ id: review.id });
+  }
+
+  @Get()
+  async findList(@Query() queries: RestaurantQueryDto): Promise<Restaurant[]> {
+    const restaurants = await this.restaurantsService.findList({
+      lon: queries.lon,
+      lat: queries.lat,
+      range: queries.range,
+      sortBy: queries.sortBy,
+      orderBy: queries.orderBy,
+      page: queries.page,
+      pageSize: queries.pageSize,
+    });
+
+    return restaurants;
   }
 }

--- a/src/restaurants/restaurants.controller.ts
+++ b/src/restaurants/restaurants.controller.ts
@@ -53,4 +53,11 @@ export class RestaurantsController {
 
     return restaurants;
   }
+
+  @Get(':id')
+  async findOneDetail(@Param('id') id: string): Promise<Restaurant | null> {
+    const restaurant = await this.restaurantsService.findOneDetail(id);
+
+    return restaurant;
+  }
 }

--- a/src/restaurants/restaurants.module.ts
+++ b/src/restaurants/restaurants.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { Restaurant } from '../entities/restaurant.entity';
+import { Review } from '../entities/review.entity';
 
 import { RestaurantsController } from './restaurants.controller';
 import { RestaurantsService } from './restaurants.service';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { Review } from 'src/entities/review.entity';
-import { Restaurant } from 'src/entities/restaurant.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Review, Restaurant])],

--- a/src/restaurants/restaurants.service.spec.ts
+++ b/src/restaurants/restaurants.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+
 import { RestaurantsService } from './restaurants.service';
 
 describe('RestaurantsService', () => {

--- a/src/restaurants/restaurants.service.spec.ts
+++ b/src/restaurants/restaurants.service.spec.ts
@@ -6,6 +6,8 @@ import { Repository, SelectQueryBuilder } from 'typeorm';
 import { Restaurant } from '../entities/restaurant.entity';
 
 import { RestaurantsService } from './restaurants.service';
+import { OrderBy, RestaurantQueryDto } from './dto/restaurant-query.dto';
+import { RestaurantResponseDto } from './dto/restaurant-response.dto';
 
 describe('RestaurantsService', () => {
   let service: RestaurantsService;
@@ -27,7 +29,7 @@ describe('RestaurantsService', () => {
   });
 
   describe('findOneDetail', () => {
-    it('should throw NotFoundException if restaurant is not found', async () => {
+    it('Restaurant가 있으면 상세 정보를 반환합니다.', async () => {
       const id = '7e3b5f25-4c58-4d88-9dc9-1d2e638ef3f9';
 
       // TypeScript에서 정확한 타입을 지정
@@ -48,7 +50,7 @@ describe('RestaurantsService', () => {
       expect(queryBuilderMock.getRawOne).toHaveBeenCalled();
     });
 
-    it('should return restaurant detail if restaurant is found', async () => {
+    it('Restaurant가 존재하면 상세 정보를 반환합니다.', async () => {
       const id = '7e3b5f25-4c58-4d88-9dc9-1d2e638ef3f9';
       const mockResult = {
         id: '1',

--- a/src/restaurants/restaurants.service.spec.ts
+++ b/src/restaurants/restaurants.service.spec.ts
@@ -1,19 +1,83 @@
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+
+import { Restaurant } from '../entities/restaurant.entity';
 
 import { RestaurantsService } from './restaurants.service';
 
 describe('RestaurantsService', () => {
   let service: RestaurantsService;
+  let repository: Repository<Restaurant>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [RestaurantsService],
+      providers: [
+        RestaurantsService,
+        {
+          provide: getRepositoryToken(Restaurant),
+          useClass: Repository, // 실제 Repository 클래스를 사용합니다.
+        },
+      ],
     }).compile();
 
     service = module.get<RestaurantsService>(RestaurantsService);
+    repository = module.get<Repository<Restaurant>>(getRepositoryToken(Restaurant));
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('findOneDetail', () => {
+    it('should throw NotFoundException if restaurant is not found', async () => {
+      const id = '7e3b5f25-4c58-4d88-9dc9-1d2e638ef3f9';
+
+      // TypeScript에서 정확한 타입을 지정
+      const queryBuilderMock: Partial<SelectQueryBuilder<Restaurant>> = {
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        leftJoin: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue(null), // mockResolvedValue 사용 가능
+      };
+
+      jest.spyOn(repository, 'createQueryBuilder').mockReturnValue(queryBuilderMock as SelectQueryBuilder<Restaurant>);
+
+      await expect(service.findOneDetail(id)).rejects.toThrow(NotFoundException);
+
+      // 모의 함수가 호출되었는지 확인
+      expect(queryBuilderMock.getRawOne).toHaveBeenCalled();
+    });
+
+    it('should return restaurant detail if restaurant is found', async () => {
+      const id = '7e3b5f25-4c58-4d88-9dc9-1d2e638ef3f9';
+      const mockResult = {
+        id: '1',
+        name: 'Restaurant A',
+        address: '123 Main St',
+        phoneNumber: '123-456-7890',
+        category: 'Italian',
+        rating: 4.5,
+        lat: 37.5,
+        lon: 127.0,
+        reviews: JSON.stringify([{ id: '1', content: 'Great food!', rating: 5 }]),
+      };
+
+      const queryBuilderMock: Partial<SelectQueryBuilder<Restaurant>> = {
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        leftJoin: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue(mockResult),
+      };
+
+      jest.spyOn(repository, 'createQueryBuilder').mockReturnValue(queryBuilderMock as SelectQueryBuilder<Restaurant>);
+
+      const result = await service.findOneDetail(id);
+      expect(result).toEqual(mockResult);
+
+      // 모의 함수가 호출되었는지 확인
+      expect(queryBuilderMock.getRawOne).toHaveBeenCalled();
+    });
   });
 });

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -70,6 +70,11 @@ export class RestaurantsService {
     this.restaurantRepository.update({ id }, { rating: updatedRating });
   }
 
+  /*
+   * 특정 위치를 기준으로 일정 거리 안에 있는 맛집들을 조회합니다.
+   * @param options 검색 조건
+   * @returns 맛집 배열
+   */
   async findList(options: RestaurantQueryDto): Promise<Restaurant[]> {
     const result = await this.restaurantRepository
       .createQueryBuilder('r')
@@ -97,6 +102,11 @@ export class RestaurantsService {
     return result;
   }
 
+  /**
+   * 맛집id를 통해 맛집의 상세 정보를 조회합니다.
+   * @param id 맛집 id
+   * @returns 리뷰를 포함한 맛집 정보
+   */
   async findOneDetail(id: string): Promise<Restaurant | null> {
     if (isUUID(id) === false) {
       throw new BadRequestException('Invalid id');


### PR DESCRIPTION
## Summary

- 맛집 목록 GET `/api/restaurants`
- 맛집 상세 조회 GET `/api/restaurants/:id`

## Describe your changes

- `validationPipe`를 통해 쿼리 유효성검사
- 목록 조회
  - `lon`, `lat`, `range`, `sortBy`(정렬 기준), `orderBy`(오름차순, 내림차순) 쿼리를 통해 맛집 목록 조회
  - `pagination` 구현 (`pageSize`, `page`)
- 상세 조회
  - uuid가 유효하지 않으면 400, 존재하지 않는 맛집이면 404

## Issue number and link
closed #6 
closed #7 