### PR TITLE
:sparkles: [Feature] 맛집 리뷰 생성 API

### DIFF
--- a/src/restaurants/dto/create-review.dto.ts
+++ b/src/restaurants/dto/create-review.dto.ts
@@ -1,0 +1,14 @@
+import { IsByteLength, IsNotEmpty, IsNumber, Max, Min } from 'class-validator';
+
+export class CreateReviewDto {
+  // 입력된 문자열의 바이트 수가 범위 안에 해당하는지 확인하는 데코레이터로, @IsString 검증도 함께함
+  @IsByteLength(10, 255)
+  @IsNotEmpty()
+  content: string;
+
+  @IsNumber()
+  @Min(1)
+  @Max(5)
+  @IsNotEmpty()
+  rating: number;
+}

--- a/src/restaurants/dto/create-review.dto.ts
+++ b/src/restaurants/dto/create-review.dto.ts
@@ -1,11 +1,18 @@
 import { IsByteLength, IsNotEmpty, IsNumber, Max, Min } from 'class-validator';
 
 export class CreateReviewDto {
-  // 입력된 문자열의 바이트 수가 범위 안에 해당하는지 확인하는 데코레이터로, @IsString 검증도 함께함
-  @IsByteLength(10, 255)
+  /**
+   * 리뷰 내용
+   * @example "너무너무 맛있어요!"
+   */
+  @IsByteLength(10, 255) // 입력된 문자열의 바이트 수 범위 확인 데코레이터로, @IsString 검증도 함께함
   @IsNotEmpty()
   content: string;
 
+  /**
+   * 리뷰 평점
+   * @example 5
+   */
   @IsNumber()
   @Min(1)
   @Max(5)

--- a/src/restaurants/restaurants.controller.spec.ts
+++ b/src/restaurants/restaurants.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RestaurantsController } from './restaurants.controller';
+import { RestaurantsService } from './restaurants.service';
+
+describe('RestaurantsController', () => {
+  let controller: RestaurantsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RestaurantsController],
+      providers: [RestaurantsService],
+    }).compile();
+
+    controller = module.get<RestaurantsController>(RestaurantsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/restaurants/restaurants.controller.ts
+++ b/src/restaurants/restaurants.controller.ts
@@ -7,7 +7,7 @@ import { Member } from '../entities/member.entity';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { RestaurantsService } from './restaurants.service';
 
-type MemberRequest = Request & {
+export type MemberRequest = Request & {
   member: Member;
 };
 

--- a/src/restaurants/restaurants.controller.ts
+++ b/src/restaurants/restaurants.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Post, Body, Param, Res, HttpStatus, Req } from '@nestjs/common';
+import { Request, Response } from 'express';
+
+import { Member } from '../entities/member.entity';
+
+import { CreateReviewDto } from './dto/create-review.dto';
+import { RestaurantsService } from './restaurants.service';
+
+interface MemberRequest extends Request {
+  member: Member;
+}
+
+@Controller('restaurants')
+export class RestaurantsController {
+  constructor(private readonly restaurantsService: RestaurantsService) {}
+
+  @Post(':id/reviews')
+  async createReview(
+    @Body() createReviewDto: CreateReviewDto,
+    @Param('id') restaurantId: string,
+    @Req() req: MemberRequest,
+    @Res() res: Response,
+  ): Promise<Response> {
+    const review = await this.restaurantsService.createReview(createReviewDto, restaurantId, req.member.id);
+    const location = `${req.path}/${review.id}`;
+
+    return res.status(HttpStatus.CREATED).setHeader('Location', location).json({ id: review.id });
+  }
+}

--- a/src/restaurants/restaurants.controller.ts
+++ b/src/restaurants/restaurants.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Post, Body, Param, Res, HttpStatus, Req } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 
 import { Member } from '../entities/member.entity';
@@ -10,10 +11,19 @@ interface MemberRequest extends Request {
   member: Member;
 }
 
+@ApiTags('restaurants')
 @Controller('restaurants')
 export class RestaurantsController {
   constructor(private readonly restaurantsService: RestaurantsService) {}
 
+  /**
+   * 리뷰 생성 API
+   * @param createReviewDto 생성할 리뷰의 내용, 평점
+   * @param restaurantId 경로변수, 리뷰를 생성할 맛집의 PK
+   * @param req 사용자 객체가 포함된 Request 객체
+   * @param res Response 객체
+   * @returns Location 헤더와 생성된 리뷰 id 바디를 포함하는 Response 객체
+   */
   @Post(':id/reviews')
   async createReview(
     @Body() createReviewDto: CreateReviewDto,

--- a/src/restaurants/restaurants.controller.ts
+++ b/src/restaurants/restaurants.controller.ts
@@ -7,9 +7,9 @@ import { Member } from '../entities/member.entity';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { RestaurantsService } from './restaurants.service';
 
-interface MemberRequest extends Request {
+type MemberRequest = Request & {
   member: Member;
-}
+};
 
 @ApiTags('restaurants')
 @Controller('restaurants')

--- a/src/restaurants/restaurants.module.ts
+++ b/src/restaurants/restaurants.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { RestaurantsController } from './restaurants.controller';
+import { RestaurantsService } from './restaurants.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Review } from 'src/entities/review.entity';
+import { Restaurant } from 'src/entities/restaurant.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Review, Restaurant])],
+  controllers: [RestaurantsController],
+  providers: [RestaurantsService],
+})
+export class RestaurantsModule {}

--- a/src/restaurants/restaurants.service.spec.ts
+++ b/src/restaurants/restaurants.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RestaurantsService } from './restaurants.service';
+
+describe('RestaurantsService', () => {
+  let service: RestaurantsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RestaurantsService],
+    }).compile();
+
+    service = module.get<RestaurantsService>(RestaurantsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -14,6 +14,13 @@ export class RestaurantsService {
     @InjectRepository(Restaurant) private readonly restaurantRepository: Repository<Restaurant>,
   ) {}
 
+  /**
+   * 사용자가 특정 맛집에 리뷰를 생성합니다. 리뷰가 생성되면 해당 맛집의 평점을 업데이트 합니다.
+   * @param createReviewDto 생성할 리뷰의 내용, 평점
+   * @param restaurantId 리뷰를 생성할 맛집의 PK
+   * @param memberId 리뷰를 생성하는 사용자의 PK
+   * @returns 생성된 리뷰의 id
+   */
   async createReview(
     createReviewDto: CreateReviewDto,
     restaurantId: string,

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -55,23 +55,16 @@ export class RestaurantsService {
     const review = await this.reviewRepository.findOneBy({ memberId, restaurantId });
 
     if (review !== null) {
-      throw new ConflictException('already reviewd');
+      throw new ConflictException('already reviewed');
     }
   }
 
   // 맛집의 모든 리뷰 기록을 조회하고, 평균을 계산하여 평점을 업데이트 합니다.
   private async updateRestaurantRating(id: string): Promise<void> {
-    const { sum, count } = (
-      await this.reviewRepository
-        .createQueryBuilder('review')
-        .select('COUNT(*) as count, SUM(rating) as sum')
-        .where('review.restaurantId = :id', { id })
-        .groupBy('review.restaurantId')
-        .execute()
-    )[0];
-
+    const averageOfRatings = await this.reviewRepository.average('rating', { restaurantId: id });
     // 소수점 한 자리까지만 나오도록
-    const updatedRating = (sum / count).toFixed(1);
+    const updatedRating = averageOfRatings.toFixed(1);
+
     this.restaurantRepository.update({ id: id }, { rating: +updatedRating });
   }
 }

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -1,0 +1,70 @@
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { Restaurant } from '../entities/restaurant.entity';
+import { Review } from '../entities/review.entity';
+
+import { CreateReviewDto } from './dto/create-review.dto';
+
+@Injectable()
+export class RestaurantsService {
+  constructor(
+    @InjectRepository(Review) private readonly reviewRepository: Repository<Review>,
+    @InjectRepository(Restaurant) private readonly restaurantRepository: Repository<Restaurant>,
+  ) {}
+
+  async createReview(
+    createReviewDto: CreateReviewDto,
+    restaurantId: string,
+    memberId: string,
+  ): Promise<{ id: string }> {
+    const { content, rating } = createReviewDto;
+
+    // 맛집 not found 예외처리
+    await this.findRestaurantById(restaurantId);
+    // 이미 리뷰를 작성한 경우에 대한 예외처리
+    await this.isAlreadyReviewd(memberId, restaurantId);
+
+    const insertResult = await this.reviewRepository.insert({ content, rating, restaurantId, memberId });
+    this.updateRestaurantRating(restaurantId);
+
+    return { id: insertResult.identifiers[0].id };
+  }
+
+  // 전달 받은 id 인자로 맛집을 찾아 반환합니다. 존재하지 않는 맛집이라면 에러를 발생시킵니다.
+  private async findRestaurantById(id: string): Promise<Restaurant> {
+    const restaurant = await this.restaurantRepository.findOneBy({ id });
+
+    if (restaurant === null) {
+      throw new NotFoundException('Restaurant not found');
+    }
+
+    return restaurant;
+  }
+
+  // 사용자가 이미 해당 맛집에 리뷰를 작성했는지 확인하고, 이미 작성했다면 에러를 발생시킵니다.
+  private async isAlreadyReviewd(memberId: string, restaurantId: string): Promise<void> {
+    const review = await this.reviewRepository.findOneBy({ memberId, restaurantId });
+
+    if (review !== null) {
+      throw new ConflictException('already reviewd');
+    }
+  }
+
+  // 맛집의 모든 리뷰 기록을 조회하고, 평균을 계산하여 평점을 업데이트 합니다.
+  private async updateRestaurantRating(id: string): Promise<void> {
+    const { sum, count } = (
+      await this.reviewRepository
+        .createQueryBuilder('review')
+        .select('COUNT(*) as count, SUM(rating) as sum')
+        .where('review.restaurantId = :id', { id })
+        .groupBy('review.restaurantId')
+        .execute()
+    )[0];
+
+    // 소수점 한 자리까지만 나오도록
+    const updatedRating = (sum / count).toFixed(1);
+    this.restaurantRepository.update({ id: id }, { rating: +updatedRating });
+  }
+}

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -55,7 +55,7 @@ export class RestaurantsService {
     const review = await this.reviewRepository.findOneBy({ memberId, restaurantId });
 
     if (review !== null) {
-      throw new ConflictException('already reviewed');
+      throw new ConflictException('Already reviewed');
     }
   }
 
@@ -63,8 +63,8 @@ export class RestaurantsService {
   private async updateRestaurantRating(id: string): Promise<void> {
     const averageOfRatings = await this.reviewRepository.average('rating', { restaurantId: id });
     // 소수점 한 자리까지만 나오도록
-    const updatedRating = averageOfRatings.toFixed(1);
+    const updatedRating = +averageOfRatings.toFixed(1);
 
-    this.restaurantRepository.update({ id: id }, { rating: +updatedRating });
+    this.restaurantRepository.update({ id }, { rating: updatedRating });
   }
 }


### PR DESCRIPTION
## Summary
`POST api/restaurants/:id/reviews` 맛집 리뷰 생성 API  
구현하였습니다.
구현 과정의 고민은 -> [Notion TIL(private)](https://www.notion.so/240831-2983bdf334d84ba8bf54a81b84b80cee)

## Describe your changes
- `restaurants.module`, `restaurants.controller`, `restaurants.service` 파일 생성해 비즈니스 로직 작성하였습니다.
- API 구현에 필요한 `create-review.dto` 파일 생성했습니다.
- id에 해당하는 맛집이 없을 때의 예외처리(404), 요청을 준 사용자가 이미 해당 맛집에 리뷰를 작성했을 때의 예외처리(409), 맛집 평점 업데이트 로직을 함수로 따로 뺐습니다.
- 스웨거 적용
  - param, returns와 같은 기본적인 설명 작성했습니다.
  - 컨트롤러 스코프로 `@ApiTags` 데코레이터를 사용해 문서에서 구분 되도록 했습니다.
  - dto에 설명과 example 작성했습니다.

## Issue number and link

#13 

- auth 머지 된 이후 가드 붙일 예정입니다.
- 테스트 코드도 그때 같이 PR 올리겠습니다!