### PR TITLE
✅ [Test] 맛집 리뷰 생성 API 유닛 테스트

### DIFF
--- a/src/restaurants/restaurants.controller.spec.ts
+++ b/src/restaurants/restaurants.controller.spec.ts
@@ -27,12 +27,12 @@ describe('RestaurantsController', () => {
     service = module.get<RestaurantsService>(RestaurantsService);
   });
 
-  it('should be define', () => {
+  it('should be defined', () => {
     expect(controller).toBeDefined();
     expect(service).toBeDefined();
   });
 
-  describe('리뷰 생성 API', () => {
+  describe('createReview', () => {
     const restaurantId = '550e8400-e29b-41d4-a716-446655440000';
     const memberId = '2bbbe5bb-5f3d-4bbb-97d8-d0ed2d7d630a';
     const reviewId = '625ad103-1fbe-404b-a865-cc09990b37ec';

--- a/src/restaurants/restaurants.controller.spec.ts
+++ b/src/restaurants/restaurants.controller.spec.ts
@@ -1,20 +1,69 @@
+import { HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { RestaurantsController } from './restaurants.controller';
+import { Response } from 'express';
+
+import { CreateReviewDto } from './dto/create-review.dto';
+import { MemberRequest, RestaurantsController } from './restaurants.controller';
 import { RestaurantsService } from './restaurants.service';
 
 describe('RestaurantsController', () => {
   let controller: RestaurantsController;
+  let service: RestaurantsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RestaurantsController],
-      providers: [RestaurantsService],
+      providers: [
+        {
+          provide: RestaurantsService,
+          useValue: {
+            createReview: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<RestaurantsController>(RestaurantsController);
+    service = module.get<RestaurantsService>(RestaurantsService);
   });
 
-  it('should be defined', () => {
+  it('should be define', () => {
     expect(controller).toBeDefined();
+    expect(service).toBeDefined();
+  });
+
+  describe('리뷰 생성 API', () => {
+    const restaurantId = '550e8400-e29b-41d4-a716-446655440000';
+    const memberId = '2bbbe5bb-5f3d-4bbb-97d8-d0ed2d7d630a';
+    const reviewId = '625ad103-1fbe-404b-a865-cc09990b37ec';
+
+    const createReviewDto: CreateReviewDto = {
+      content: '너무너무 맛있어요!',
+      rating: 5,
+    };
+
+    const req = {
+      path: `/restaurants/${restaurantId}/reviews`,
+      member: { id: memberId },
+    } as MemberRequest;
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      setHeader: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    } as Partial<Response> as Response;
+
+    it('리뷰 생성하고 Location 헤더와 함께 응답 객체 반환', async () => {
+      const review = { id: reviewId };
+      jest.spyOn(service, 'createReview').mockResolvedValue(review);
+
+      const result = await controller.createReview(createReviewDto, restaurantId, req, res);
+
+      expect(service.createReview).toHaveBeenCalledWith(createReviewDto, restaurantId, memberId);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.CREATED);
+      expect(res.setHeader).toHaveBeenCalledWith('Location', `${req.path}/${review.id}`);
+      expect(res.json).toHaveBeenCalledWith({ id: review.id });
+      expect(result).toBe(res);
+    });
   });
 });

--- a/src/restaurants/restaurants.service.spec.ts
+++ b/src/restaurants/restaurants.service.spec.ts
@@ -1,18 +1,101 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { InsertResult, Repository, UpdateResult } from 'typeorm';
+
+import { Restaurant } from '../entities/restaurant.entity';
+import { Review } from '../entities/review.entity';
+
 import { RestaurantsService } from './restaurants.service';
 
 describe('RestaurantsService', () => {
   let service: RestaurantsService;
+  let reviewRepository: Repository<Review>;
+  let restaurantRepository: Repository<Restaurant>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [RestaurantsService],
+      providers: [
+        RestaurantsService,
+        {
+          provide: getRepositoryToken(Review),
+          useClass: Repository,
+        },
+        {
+          provide: getRepositoryToken(Restaurant),
+          useClass: Repository,
+        },
+      ],
     }).compile();
 
     service = module.get<RestaurantsService>(RestaurantsService);
+    reviewRepository = module.get<Repository<Review>>(getRepositoryToken(Review));
+    restaurantRepository = module.get<Repository<Restaurant>>(getRepositoryToken(Restaurant));
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+    expect(reviewRepository).toBeDefined();
+    expect(restaurantRepository).toBeDefined();
+  });
+
+  describe('createReview', () => {
+    const restaurantId = '550e8400-e29b-41d4-a716-446655440000';
+    const memberId = '2bbbe5bb-5f3d-4bbb-97d8-d0ed2d7d630a';
+    const reviewId = '625ad103-1fbe-404b-a865-cc09990b37ec';
+    const createReviewDto = {
+      content: '너무너무 맛있어요.',
+      rating: 5,
+    };
+
+    it('성공적으로 리뷰를 생성하고 생성된 리뷰의 id 반환', async () => {
+      const rating = 4.3;
+      const restaurant = { id: restaurantId } as Restaurant;
+
+      jest.spyOn(restaurantRepository, 'findOneBy').mockResolvedValue(restaurant);
+      jest.spyOn(reviewRepository, 'findOneBy').mockResolvedValue(null);
+      jest
+        .spyOn(reviewRepository, 'insert')
+        .mockResolvedValue({ identifiers: [{ id: reviewId }] } as unknown as InsertResult);
+      jest.spyOn(reviewRepository, 'average').mockResolvedValue(rating);
+      jest
+        .spyOn(restaurantRepository, 'update')
+        .mockResolvedValue({ ...restaurant, rating } as unknown as UpdateResult);
+
+      const result = await service.createReview(createReviewDto, restaurantId, memberId);
+
+      expect(restaurantRepository.findOneBy).toHaveBeenCalledWith({ id: restaurantId });
+      expect(reviewRepository.findOneBy).toHaveBeenCalledWith({ memberId, restaurantId });
+      expect(reviewRepository.insert).toHaveBeenCalledWith({ ...createReviewDto, restaurantId, memberId });
+      expect(reviewRepository.average).toHaveBeenCalledWith('rating', { restaurantId });
+      expect(restaurantRepository.update).toHaveBeenCalledWith({ id: restaurantId }, { rating });
+
+      expect(result).toEqual({ id: reviewId });
+    });
+
+    it('존재하지 않는 맛집인 경우 404', async () => {
+      jest.spyOn(restaurantRepository, 'findOneBy').mockResolvedValue(null);
+      jest.spyOn(reviewRepository, 'findOneBy');
+
+      await expect(service.createReview(createReviewDto, restaurantId, memberId)).rejects.toThrow(NotFoundException);
+
+      expect(restaurantRepository.findOneBy).toHaveBeenCalledWith({ id: restaurantId });
+      expect(reviewRepository.findOneBy).not.toHaveBeenCalled();
+    });
+
+    it('사용자가 이미 해당 맛집에 리뷰를 작성한 경우 409', async () => {
+      const restaurant = { id: restaurantId } as Restaurant;
+      const review = { id: reviewId } as Review;
+
+      jest.spyOn(restaurantRepository, 'findOneBy').mockResolvedValue(restaurant);
+      jest.spyOn(reviewRepository, 'findOneBy').mockResolvedValue(review);
+      jest.spyOn(reviewRepository, 'insert');
+
+      await expect(service.createReview(createReviewDto, restaurantId, memberId)).rejects.toThrow(ConflictException);
+
+      expect(restaurantRepository.findOneBy).toHaveBeenCalledWith({ id: restaurantId });
+      expect(reviewRepository.findOneBy).toHaveBeenCalledWith({ restaurantId, memberId });
+      expect(reviewRepository.insert).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary
맛집 리뷰 생성 API의 컨트롤러, 서비스 파일 유닛 테스트 코드를 작성하였습니다.  
다른 케이스는 생각이 잘 안 나서 커버리지 100 맞추는 느낌으로...  
`npm run test:cov`를 한 뒤, `coverage/lcov-report/index.html` 을 열면 보실 수 있습니다!

## Describe your changes

## Issue number and link
close #27 