### PR TITLE
✅ [Test] 사용자 정보 조회 API, 설정 업데이트 API 유닛 테스트

### DIFF
--- a/src/members/members.controller.spec.ts
+++ b/src/members/members.controller.spec.ts
@@ -3,7 +3,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from '../auth/auth.service';
 
 import { CreateMemberDto } from './dto/create-member.dto';
+import { MemberResponseDto } from './dto/member-response.dto';
 import { SignInDto } from './dto/sign-in.dto';
+import { UpdateMemberSettingsDto } from './dto/update-member-settings.dto';
 import { MembersController } from './members.controller';
 import { MembersService } from './members.service';
 
@@ -20,6 +22,8 @@ describe('MembersController', () => {
           provide: MembersService,
           useValue: {
             createMember: jest.fn(),
+            findOne: jest.fn(),
+            updateSettings: jest.fn(),
           },
         },
         {
@@ -35,6 +39,12 @@ describe('MembersController', () => {
     controller = module.get<MembersController>(MembersController);
     membersService = module.get<MembersService>(MembersService);
     authService = module.get<AuthService>(AuthService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+    expect(membersService).toBeDefined();
+    expect(authService).toBeDefined();
   });
 
   describe('createMember', () => {
@@ -91,6 +101,29 @@ describe('MembersController', () => {
 
       expect(result).toEqual(mockNewAccessToken);
       expect(authService.refreshAccessToken).toHaveBeenCalledWith('99fde318-0000-4000-8000-000000000000');
+    });
+  });
+
+  describe('findOne', () => {
+    const memberId = '60b8a1ba-1b9b-45f7-aa58-50d0c87da51f';
+    const memberResponseDto = {
+      id: memberId,
+      accountName: 'accountName',
+      name: 'name',
+      lat: 37.564084,
+      lon: 126.977079,
+      isRecommendationEnabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as MemberResponseDto;
+
+    it('성공적으로 사용자를 찾아 반환', async () => {
+      jest.spyOn(membersService, 'findOne').mockResolvedValue(memberResponseDto);
+
+      const result = await controller.findOne(memberId);
+
+      expect(membersService.findOne).toHaveBeenCalledWith(memberId);
+      expect(result).toEqual(memberResponseDto);
     });
   });
 });

--- a/src/members/members.controller.spec.ts
+++ b/src/members/members.controller.spec.ts
@@ -126,4 +126,22 @@ describe('MembersController', () => {
       expect(result).toEqual(memberResponseDto);
     });
   });
+
+  describe('updateSettings', () => {
+    const memberId = '60b8a1ba-1b9b-45f7-aa58-50d0c87da51f';
+    const updateMemberSettingsDto = {
+      lat: 37.564084,
+      lon: 126.977079,
+      isRecommendationEnabled: true,
+    } as UpdateMemberSettingsDto;
+
+    it('성공적으로 사용자 설정 업데이트', () => {
+      jest.spyOn(membersService, 'updateSettings').mockResolvedValue(undefined);
+
+      const result = controller.updateSettings(memberId, updateMemberSettingsDto);
+
+      expect(membersService.updateSettings).toHaveBeenCalledWith(memberId, updateMemberSettingsDto);
+      expect(result).toBeUndefined();
+    });
+  });
 });

--- a/src/members/members.service.spec.ts
+++ b/src/members/members.service.spec.ts
@@ -1,12 +1,13 @@
-import { ConflictException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import * as bcrypt from 'bcrypt';
-import { Repository } from 'typeorm';
+import { Point, Repository } from 'typeorm';
 
 import { Member } from '../entities/member.entity';
 
 import { CreateMemberDto } from './dto/create-member.dto';
+import { MemberResponseDto } from './dto/member-response.dto';
 import { MembersService } from './members.service';
 
 jest.mock('bcrypt');
@@ -19,6 +20,7 @@ describe('MembersService', () => {
     mockRepository = {
       findOneBy: jest.fn(),
       insert: jest.fn(),
+      update: jest.fn(),
     } as unknown as Repository<Member>;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -82,6 +84,61 @@ describe('MembersService', () => {
 
       expect(mockRepository.findOneBy).toHaveBeenCalledWith({ accountName: 'existinguser' });
       expect(mockRepository.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findOne', () => {
+    const memberId = '60b8a1ba-1b9b-45f7-aa58-50d0c87da51f';
+    const member = {
+      id: memberId,
+      accountName: 'accountName',
+      name: 'name',
+      password: 'hashedPassword',
+      location: { type: 'Point', coordinates: [37.564084, 126.977079] } as Point,
+      isRecommendationEnabled: true,
+      reviews: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as Member;
+    const memberResponseDto = {
+      id: member.id,
+      accountName: member.accountName,
+      name: member.name,
+      lat: member.location.coordinates[0],
+      lon: member.location.coordinates[1],
+      isRecommendationEnabled: member.isRecommendationEnabled,
+      createdAt: member.createdAt,
+      updatedAt: member.updatedAt,
+    } as MemberResponseDto;
+
+    it('성공적으로 한 사용자를 찾아 반환', async () => {
+      jest.spyOn(mockRepository, 'findOneBy').mockResolvedValue(member);
+
+      const result = await service.findOne(memberId);
+
+      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ id: memberId });
+      expect(result).toEqual(memberResponseDto);
+    });
+
+    it('사용자의 위도, 경도 정보가 없는 경우 null로 반환', async () => {
+      member.location = null;
+      memberResponseDto.lat = null;
+      memberResponseDto.lon = null;
+
+      jest.spyOn(mockRepository, 'findOneBy').mockResolvedValue(member);
+
+      const result = await service.findOne(memberId);
+
+      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ id: memberId });
+      expect(result).toEqual(memberResponseDto);
+    });
+
+    it('사용자가 존재하지 않을 경우 404', async () => {
+      jest.spyOn(mockRepository, 'findOneBy').mockResolvedValue(null);
+
+      await expect(service.findOne(memberId)).rejects.toThrow(NotFoundException);
+
+      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ id: memberId });
     });
   });
 });

--- a/src/members/members.service.ts
+++ b/src/members/members.service.ts
@@ -46,7 +46,7 @@ export class MembersService {
    */
   async findOne(id: string): Promise<MemberResponseDto> {
     const member = await this.findMemberById(id);
-    const [lat, lon] = member.location?.coordinates;
+    const [lat, lon] = member.location?.coordinates || [null, null];
 
     return {
       id: member.id,


### PR DESCRIPTION
## Summary
사용자 정보 조회 API, 사용자 설정 업데이트 API의 유닛 테스트를 작성했습니다.  
드디어 헤헤헤헤

## Describe your changes
- 서비스 코드에서 옵셔널 체이닝 연산자 `?.`를 사용해서 참조 에러를 방지하고 있었는데, 배열 구조 분해 할당을 하고 있어서, 만약 `null`일 경우 `null`은 이터러블이 아니라 할당 과정에서 에러가 난다는 걸 알게 되어 수정하였습니다. (그냥 `undefined`로 할당될 줄 알았어요!)

## Issue number and link
close #28 
close #29 